### PR TITLE
Add restaurant: Franco Manca | Russell Square

### DIFF
--- a/data/restaurants.yaml
+++ b/data/restaurants.yaml
@@ -8,6 +8,15 @@ restaurants:
     score: 3
     notes: Neither fast-food, nor proper Neapolitan pizza. Dull knives.
     visited: '2024-12-28'
+  - name: Franco Manca | Russell Square
+    address: 4 Bernard St, Russell Sq, London WC1N 1LJ, UK
+    coordinates:
+      lat: 51.5230666
+      lng: -0.1246824
+    maps_url: https://www.google.com/maps/place/?q=place_id:ChIJiQRo3jAbdkgRtEwh9iGpvM8
+    score: 4
+    notes: Good Franco Manca spot, used to go there a lot!
+    visited: '2024-12-29'
   - name: Franco Manca Covent Garden
     address: 39 Maiden Ln, London WC2E 7LJ, UK
     coordinates:


### PR DESCRIPTION
Adding new restaurant:
      
- Name: Franco Manca | Russell Square
- Address: 4 Bernard St, Russell Sq, London WC1N 1LJ, UK
- Score: 4/5
- Notes: Good Franco Manca spot, used to go there a lot!
- Visited: 2024-12-29