### PR TITLE
Add restaurant: Churchill College

### DIFF
--- a/data/restaurants.yaml
+++ b/data/restaurants.yaml
@@ -40,6 +40,17 @@ restaurants:
     maps_url: https://www.google.com/maps/place/?q=place_id:ChIJxcxBeqp3nkcRQsZKCJ1bs2o
     score: 3
     notes: Cheap, quick and good! Recommended with Apfelshorle🧃
+  - name: Churchill College
+    address: University of Cambridge, Storey's Way, Cambridge CB3 0DS, UK
+    coordinates:
+      lat: 52.21253489999999
+      lng: 0.1040989
+    maps_url: https://www.google.com/maps/place/?q=place_id:ChIJU7qLacpw2EcRHniCJnYaiIg
+    score: 4
+    notes: >-
+      The sourdough pizza at the Buttery saved me maaany times. 4 for the
+      vibes! 
+    visited: '2025-03-16'
   - name: Franco Manca | Cambridge
     address: 15 Market Hill, Cambridge CB2 3NP, UK
     coordinates:


### PR DESCRIPTION
Adding new restaurant:
      
- Name: Churchill College
- Address: University of Cambridge, Storey's Way, Cambridge CB3 0DS, UK
- Score: 4/5
- Notes: The sourdough pizza at the Buttery saved me maaany times. 4 for the vibes! 
- Visited: 2025-03-16