### PR TITLE
Add restaurant: Ideolo Pizza Szczecin

### DIFF
--- a/data/restaurants.yaml
+++ b/data/restaurants.yaml
@@ -1,13 +1,4 @@
 restaurants:
-  - name: Alice Pizza Ostiense
-    address: Via Ostiense, 48, 00154 Roma RM, Italy
-    coordinates:
-      lat: 41.8721561
-      lng: 12.4798579
-    maps_url: https://www.google.com/maps/place/?q=place_id:ChIJA0pdtytgLxMRedmKz5HCna8
-    score: 3
-    notes: Sliced to-go Rome-style pizza
-    visited: '2025-05-22'
   - name: 50 Kalò di Ciro Salvo - Roma
     address: Via Flavia, 3b, 00187 Roma RM, Italy
     coordinates:
@@ -17,6 +8,15 @@ restaurants:
     score: 4
     notes: 'Good Neapolitan pizza compensating Emilka''s wet laptop 😬 '
     visited: '2025-05-23'
+  - name: Alice Pizza Ostiense
+    address: Via Ostiense, 48, 00154 Roma RM, Italy
+    coordinates:
+      lat: 41.8721561
+      lng: 12.4798579
+    maps_url: https://www.google.com/maps/place/?q=place_id:ChIJA0pdtytgLxMRedmKz5HCna8
+    score: 3
+    notes: Sliced to-go Rome-style pizza
+    visited: '2025-05-22'
   - name: Aromi Caffe and Pizzeria
     address: 1 Bene't St, Cambridge CB2 3QN, UK
     coordinates:
@@ -116,6 +116,14 @@ restaurants:
     notes: >-
       Truly the People's Pizzeria! Cheapest pizza in town, feeding me well
       during the undergrad 🎓
+  - name: Ideolo Pizza Szczecin
+    address: al. Wyzwolenia 44a, 71-500 Szczecin, Poland
+    coordinates:
+      lat: 53.4372719
+      lng: 14.5545221
+    maps_url: https://www.google.com/maps/place/?q=place_id:ChIJYUKfS4UJqkcRndw7JDQa6rY
+    score: 3
+    notes: Good selection of vegetarian pizzas. Decent size!
   - name: Jacuzzi
     address: 94 Kensington High St, London W8 4SH, UK
     coordinates:


### PR DESCRIPTION
Adding new restaurant:
      
- Name: Ideolo Pizza Szczecin
- Address: al. Wyzwolenia 44a, 71-500 Szczecin, Poland
- Score: 3/5
- Notes: Good selection of vegetarian pizzas. Decent size!
