### PR TITLE
Add restaurant: Pizza Paradise

### DIFF
--- a/data/restaurants.yaml
+++ b/data/restaurants.yaml
@@ -218,6 +218,17 @@ restaurants:
     maps_url: https://www.google.com/maps/place/?q=place_id:ChIJxS1YNMEPqkcRMSfo_zUxGTw
     score: 2
     notes: Honestly, I tried it twice and could never finish.
+  - name: Pizza Paradise
+    address: 4-6 South Bridge, Edinburgh EH1 1LL, UK
+    coordinates:
+      lat: 55.9498826
+      lng: -3.1872405
+    maps_url: https://www.google.com/maps/place/?q=place_id:ChIJT_Z6hYXHh0gRDmsasZXtX_4
+    score: 3
+    notes: >-
+      Open till late, honestly a lifesaver after arriving late by train in full
+      rain. The waitress was genuinely concerned lol 
+    visited: '2025-07-06'
   - name: Pizza Sophia
     address: 50 Tavistock Pl, London WC1H 9RG, UK
     coordinates:


### PR DESCRIPTION
Adding new restaurant:
      
- Name: Pizza Paradise
- Address: 4-6 South Bridge, Edinburgh EH1 1LL, UK
- Score: 3/5
- Notes: Open till late, honestly a lifesaver after arriving late by train in full rain. The waitress was genuinely concerned lol 
- Visited: 2025-07-06